### PR TITLE
Added ignore for update tasks

### DIFF
--- a/ansible/playbooks/run_updates.yml
+++ b/ansible/playbooks/run_updates.yml
@@ -14,9 +14,11 @@
         state: latest
         update_cache: true
       when: is_debian
+      # noqa package-latest
     - name: Update all packages (RHEL)
       ansible.builtin.dnf:
         name: '*'
         state: latest
         update_cache: true
       when: is_rhel
+      # noqa package-latest

--- a/ansible/playbooks/run_updates.yml
+++ b/ansible/playbooks/run_updates.yml
@@ -13,12 +13,13 @@
         name: '*'
         state: latest
         update_cache: true
+        only_upgrade: true
       when: is_debian
-      # noqa package-latest
+
     - name: Update all packages (RHEL)
       ansible.builtin.dnf:
         name: '*'
         state: latest
         update_cache: true
+        update_only: true
       when: is_rhel
-      # noqa package-latest


### PR DESCRIPTION
I need these tasks to update all to latest, so lets ignore the ansible-lint warning for these rules

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Update process now restricts upgrades to already-installed packages only, preventing new package installations during routine updates.
  * No changes to conditional behavior or public interfaces; deployment flow and access remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->