### PR TITLE
Added installer of ansible dependancies to gh actions

### DIFF
--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v6
+      - name: Install Ansible collections
+        run: ansible-galaxy collection install -r ansible/requirements.yml
       - name: Run ansible-lint
         uses: ansible/ansible-lint@8ba9595a4acd1b906eb75568b34f6ef592cd1528
         with:

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -20,4 +20,4 @@ jobs:
           setup_python: true
           python_version: "3.14"
           working_directory: "ansible"
-          requirements_file: "requirements.yml"
+          requirements_file: "ansible/requirements.yml"

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -20,4 +20,4 @@ jobs:
           setup_python: true
           python_version: "3.14"
           working_directory: "ansible"
-          requirements_file: "ansible/requirements.yml"
+          requirements_file: "requirements.yml"

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -10,14 +10,33 @@ jobs:
   ansible-lint:
     name: Ansible Lint
     runs-on: ubuntu-24.04
+
+    env:
+      ANSIBLE_COLLECTIONS_PATH: ${{ github.workspace }}/ansible/collections
     steps:
-      - uses: actions/checkout@v6
-      - name: Install Ansible collections
-        run: ansible-galaxy collection install -r ansible/requirements.yml
-      - name: Run ansible-lint
-        uses: ansible/ansible-lint@8ba9595a4acd1b906eb75568b34f6ef592cd1528
+      - name: Checkout repository
+        uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v1
+      - name: Set up Python
+        uses: actions/setup-python@v5
         with:
-          setup_python: true
-          python_version: "3.14"
-          working_directory: "ansible"
-          requirements_file: "requirements.yml"
+          python-version: "3.14"  # safer than 3.14 for now
+
+      # Sync dependencies from uv.lock
+      - name: Install Python dependencies
+        run: uv sync
+
+      # Install Ansible collections into repo-local path
+      - name: Install Ansible collections
+        run: |
+          mkdir -p ansible/collections
+          uv run ansible-galaxy collection install \
+            -r ansible/requirements.yml \
+            -p ansible/collections
+
+      # Run ansible-lint inside uv environment
+      - name: Run ansible-lint
+        run: |
+          cd ansible
+          uv run ansible-lint

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -25,10 +25,12 @@ jobs:
 
       # Sync dependencies from uv.lock
       - name: Install Python dependencies
+        working-directory: ansible
         run: uv sync
 
       # Install Ansible collections into repo-local path
       - name: Install Ansible collections
+        working-directory: ansible
         run: |
           mkdir -p ansible/collections
           uv run ansible-galaxy collection install \
@@ -37,6 +39,7 @@ jobs:
 
       # Run ansible-lint inside uv environment
       - name: Run ansible-lint
+        working-directory: ansible
         run: |
           cd ansible
           uv run ansible-lint

--- a/.github/workflows/ansible_lint.yml
+++ b/.github/workflows/ansible_lint.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.14"  # safer than 3.14 for now
+          python-version: "3.13"
 
       # Sync dependencies from uv.lock
       - name: Install Python dependencies
@@ -32,14 +32,12 @@ jobs:
       - name: Install Ansible collections
         working-directory: ansible
         run: |
-          mkdir -p ansible/collections
+          mkdir -p collections
           uv run ansible-galaxy collection install \
-            -r ansible/requirements.yml \
-            -p ansible/collections
+            -r requirements.yml \
+            -p collections
 
       # Run ansible-lint inside uv environment
       - name: Run ansible-lint
         working-directory: ansible
-        run: |
-          cd ansible
-          uv run ansible-lint
+        run: uv run ansible-lint


### PR DESCRIPTION
The ansible-lint action on github actions have started to get issues of unresolved dependancies.
Hopefully this will fix these issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI linting workflow updated to set a repo-local collections path, explicitly install Python tooling and project dependencies, install required Ansible collections into the repo, and run linting through the installed toolchain—improving reliability and reducing intermittent CI lint failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->